### PR TITLE
Add additional sign and verify options at method level to override default JWT_MODULE_OPTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ It works the same as `useClass` with one critical difference - `JwtModule` will 
 
 The `JwtService` uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken) underneath.
 
-#### jwtService.sign(payload: string | Object | Buffer): string
+#### jwtService.sign(payload: string | Object | Buffer, options?: SignOptions): string
 The sign method is an implementation of jsonwebtoken `.sign()`.
 
-#### jwtService.verify\<T extends object = any>(token: string): T
+#### jwtService.verify\<T extends object = any>(token: string, options?: VerifyOptions): T
 The sign method is an implementation of jsonwebtoken `.verify()`.
 
 #### jwtService.decode(token: string, options: DecodeOptions): object | string

--- a/lib/jwt.service.ts
+++ b/lib/jwt.service.ts
@@ -9,19 +9,30 @@ export class JwtService {
     @Inject(JWT_MODULE_OPTIONS) private readonly options: JwtModuleOptions
   ) {}
 
-  sign(payload: string | Object | Buffer): string {
-    return jwt.sign(
-      payload,
-      this.options.secretOrPrivateKey,
-      this.options.signOptions
-    );
+  sign(payload: string | Object | Buffer, options?: jwt.SignOptions): string {
+    const signOptions = options
+      ? {
+          ...this.options.signOptions,
+          ...options
+        }
+      : this.options.signOptions;
+    return jwt.sign(payload, this.options.secretOrPrivateKey, signOptions);
   }
 
-  verify<T extends object = any>(token: string): T {
+  verify<T extends object = any>(
+    token: string,
+    options?: jwt.VerifyOptions
+  ): T {
+    const verifyOptions = options
+      ? {
+          ...this.options.verifyOptions,
+          ...options
+        }
+      : this.options.verifyOptions;
     return jwt.verify(
       token,
       this.options.publicKey || (this.options.secretOrPrivateKey as any),
-      this.options.verifyOptions
+      verifyOptions
     ) as T;
   }
 

--- a/lib/jwt.service.ts
+++ b/lib/jwt.service.ts
@@ -12,7 +12,7 @@ export class JwtService {
   sign(payload: string | Object | Buffer, options?: jwt.SignOptions): string {
     const signOptions = options
       ? {
-          ...this.options.signOptions,
+          ...(this.options.signOptions || {}),
           ...options
         }
       : this.options.signOptions;
@@ -25,7 +25,7 @@ export class JwtService {
   ): T {
     const verifyOptions = options
       ? {
-          ...this.options.verifyOptions,
+          ...(this.options.verifyOptions || {}),
           ...options
         }
       : this.options.verifyOptions;


### PR DESCRIPTION
Override default options in JwtService for sign and verify with jwt.SignOptions and jwt.VerifyOptions objects provided at method level.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Override jwt.signOptions and jwt.verifyOptions in JwtService to be able to generate tokens with different validity time (eg: authorization token & refresh token).

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1 


## What is the new behavior?
The options to be provided for sign and verify are optionals. Nothing would change in for the current workings. This adds the possibility to change the default JWT_MODULE_OPTIONS provided ad construction time. This is needed to generate 2 tokens: authorization and refresh tokens. These need to have different exp time, so we need to provide different options when signing and verifying them.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information