### PR TITLE
feat(verify): verify jwt asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,16 @@ The `JwtService` uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
 #### jwtService.sign(payload: string | Object | Buffer, options?: SignOptions): string
 The sign method is an implementation of jsonwebtoken `.sign()`.
 
-#### jwtService.verify\<T extends object = any>(token: string, options?: VerifyOptions): T
-The sign method is an implementation of jsonwebtoken `.verify()`.
+#### jwtService.verify\<T extends object = any>(token: string, options?: VerifyOptions): void
+The verify method is an implementation of jsonwebtoken `.verify()`.
 
 #### jwtService.decode(token: string, options: DecodeOptions): object | string
-The sign method is an implementation of jsonwebtoken `.decode()`.
+The decode method is an implementation of jsonwebtoken `.decode()`.
 
 The `JwtModule` takes an `options` object:
 - `secretOrPrivateKey` [read more](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback)
 - `signOptions` [read more](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback)
-- `publicKey` PEM encoded public key for RSA and ECDSA
+- `publicKey` PEM encoded public key for RSA and ECDSA [read more](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)
 - `verifyOptions` [read more](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)
 
 ## Support

--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -4,7 +4,7 @@ import * as jwt from 'jsonwebtoken';
 export interface JwtModuleOptions {
   signOptions?: jwt.SignOptions;
   secretOrPrivateKey?: jwt.Secret;
-  publicKey?: string | Buffer;
+  publicKey?: string | Buffer | jwt.GetSecretOrPublicKeyCallback;
   verifyOptions?: jwt.VerifyOptions;
 }
 

--- a/lib/jwt.service.ts
+++ b/lib/jwt.service.ts
@@ -35,9 +35,9 @@ export class JwtService {
       verifyOptions,
       (error, jwtPayload) => {
         if (error) {
-          throw error
+          throw error;
         }
-        return jwtPayload
+        return jwtPayload;
       }
     );
   }

--- a/lib/jwt.service.ts
+++ b/lib/jwt.service.ts
@@ -22,18 +22,24 @@ export class JwtService {
   verify<T extends object = any>(
     token: string,
     options?: jwt.VerifyOptions
-  ): T {
+  ): void {
     const verifyOptions = options
       ? {
           ...(this.options.verifyOptions || {}),
           ...options
         }
       : this.options.verifyOptions;
-    return jwt.verify(
+     return jwt.verify(
       token,
       this.options.publicKey || (this.options.secretOrPrivateKey as any),
-      verifyOptions
-    ) as T;
+      verifyOptions,
+      (error, jwtPayload) => {
+        if (error) {
+          throw error
+        }
+        return jwtPayload
+      }
+    );
   }
 
   decode(

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "dependencies": {
-    "@types/jsonwebtoken": "^7.2.7",
+    "@types/jsonwebtoken": "^7.2.9",
     "jsonwebtoken": "^8.3.0"
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`jwtService.verify` calls `jwt.verify`synchronously.

Issue Number: [add support for json web key sets #6](https://github.com/nestjs/jwt/issues/6)


## What is the new behavior?
`jwtService.verify` now calls `jwt.verify` asynchronously. When `jwt.verify` is called asynchronously, `publicKey` _can_ be a function that can fetch public key.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information