### PR TITLE
feature: dynamic secret/keys via secretOrKeyProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Import `JwtModule`:
 
 ```typescript
 @Module({
-  imports: [JwtModule.register({ secretOrPrivateKey: 'key' })],
+  imports: [JwtModule.register({ secret: 'hard!to-guess_secret' })],
   providers: [...],
 })
 export class AuthModule {}
@@ -55,6 +55,41 @@ export class AuthService {
 }
 ```
 
+## Secret / Encryption Key options
+
+If you want to control secret and key management dynamically you can use the `secretOrKeyProvider` function for that purpose.
+
+```typescript
+JwtModule.register({
+  /* Dynamic key provider has precedance over static secret or pub/private keys */
+  secretOrKeyProvider: (
+    requestType: JwtSecretRequestType,
+    tokenOrPayload: string | Object | Buffer,
+    verifyOrSignOrOptions?: jwt.VerifyOptions | jwt.SignOptions
+  ) => {
+    switch (requestType) {
+      case JwtSecretRequestType.SIGN:
+        // retrieve signing key dynamically
+        return 'privateKey';
+      case JwtSecretRequestType.VERIFY:
+        // retrieve public key for verification dynamically
+        return 'publicKey';
+      default:
+        // retrieve secret dynamically
+        return 'hard!to-guess_secret';
+    }
+  },
+  /* Secret has precedance over keys */
+  secret: 'hard!to-guess_secret',
+
+  /* public key used in asymmetric algorithms (required if non other secrets present) */
+  publicKey: '...',
+
+  /* private key used in asymmetric algorithms (required if non other secrets present) */
+  privateKey: '...'
+});
+```
+
 ## Async options
 
 Quite often you might want to asynchronously pass your module options instead of passing them beforehand. In such case, use `registerAsync()` method, that provides a couple of various ways to deal with async data.
@@ -64,7 +99,7 @@ Quite often you might want to asynchronously pass your module options instead of
 ```typescript
 JwtModule.registerAsync({
   useFactory: () => ({
-    secretOrPrivateKey: 'key'
+    secret: 'hard!to-guess_secret'
   })
 });
 ```
@@ -75,7 +110,7 @@ Obviously, our factory behaves like every other one (might be `async` and is abl
 JwtModule.registerAsync({
   imports: [ConfigModule],
   useFactory: async (configService: ConfigService) => ({
-    secretOrPrivateKey: configService.getString('SECRET_KEY'),
+    secret: configService.getString('SECRET'),
   }),
   inject: [ConfigService],
 }),
@@ -95,7 +130,7 @@ Above construction will instantiate `JwtConfigService` inside `JwtModule` and wi
 class JwtConfigService implements JwtOptionsFactory {
   createJwtOptions(): JwtModuleOptions {
     return {
-      secretOrPrivateKey: 'key'
+      secret: 'hard!to-guess_secret'
     };
   }
 }
@@ -139,6 +174,8 @@ The decode method is an implementation of jsonwebtoken `.decode()`.
 The `JwtModule` takes an `options` object:
 
 - `secretOrPrivateKey` [read more](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback)
+- `secretOrPublicKey` [read more](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)
+- `secretOrKeyProvider` [read more](https://github.com/themikenicholson/passport-jwt/blob/master/README.md#configure-strategy)
 - `signOptions` [read more](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback)
 - `publicKey` PEM encoded public key for RSA and ECDSA
 - `verifyOptions` [read more](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)

--- a/jest.json
+++ b/jest.json
@@ -1,0 +1,13 @@
+{
+  "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+  "transform": {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+  "testRegex": "/lib/.*\\.(test|spec).(ts|tsx|js)$",
+  "collectCoverageFrom": [
+    "lib/**/*.{js,jsx,tsx,ts}",
+    "!**/node_modules/**",
+    "!**/vendor/**"
+  ],
+  "coverageReporters": ["json", "lcov"]
+}

--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -1,10 +1,21 @@
 import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
 import * as jwt from 'jsonwebtoken';
 
+export enum JwtSecretRequestType {
+  SIGN,
+  VERIFY
+}
 export interface JwtModuleOptions {
   signOptions?: jwt.SignOptions;
-  secretOrPrivateKey?: jwt.Secret;
+  secret?: string | Buffer;
   publicKey?: string | Buffer;
+  privateKey?: jwt.Secret;
+  secretOrPrivateKey?: jwt.Secret; // TODO: deprecated
+  secretOrKeyProvider?: (
+    requestType: JwtSecretRequestType,
+    tokenOrPayload: string | object | Buffer,
+    options?: jwt.VerifyOptions | jwt.SignOptions
+  ) => jwt.Secret;
   verifyOptions?: jwt.VerifyOptions;
 }
 

--- a/lib/jwt.spec.ts
+++ b/lib/jwt.spec.ts
@@ -1,0 +1,155 @@
+import { Test } from '@nestjs/testing';
+import { JwtModule } from './jwt.module';
+import { JwtService } from './jwt.service';
+
+import * as jwt from 'jsonwebtoken';
+import {
+  JwtSecretRequestType,
+  JwtModuleOptions
+} from './interfaces/jwt-module-options.interface';
+
+const setup = async (config: JwtModuleOptions) => {
+  const module = await Test.createTestingModule({
+    imports: [JwtModule.register(config)]
+  }).compile();
+
+  return module.get<JwtService>(JwtService);
+};
+
+const config = {
+  secretOrKeyProvider: (requestType: JwtSecretRequestType) =>
+    requestType === JwtSecretRequestType.SIGN ? 'S' : 'V',
+  secret: 'B',
+  publicKey: 'C',
+  privateKey: 'D'
+};
+
+describe('JWT Service', () => {
+  beforeAll(async () => {
+    jest
+      .spyOn(jwt, 'sign')
+      .mockImplementation((token, secret, options) => secret);
+
+    jest
+      .spyOn(jwt, 'verify')
+      .mockImplementation((token, secret, options) => secret);
+  });
+
+  describe('should use secretOrKeyProvider', () => {
+    let jwtService: JwtService;
+
+    beforeAll(async () => {
+      jwtService = await setup(config);
+    });
+
+    it('signing should use SIGN option function', async () => {
+      expect(await jwtService.sign('random')).toBe(
+        config.secretOrKeyProvider(JwtSecretRequestType.SIGN)
+      );
+    });
+
+    it('signing (async) should use SIGN option function', async () => {
+      expect(jwtService.signAsync('random')).resolves.toBe(
+        config.secretOrKeyProvider(JwtSecretRequestType.SIGN)
+      );
+    });
+
+    it('verifying should use VERIFY option function', async () => {
+      expect(await jwtService.verify('random')).toBe(
+        config.secretOrKeyProvider(JwtSecretRequestType.VERIFY)
+      );
+    });
+
+    it('verifying (async) should use SIGN option function', async () => {
+      expect(jwtService.verifyAsync('random')).resolves.toBe(
+        config.secretOrKeyProvider(JwtSecretRequestType.VERIFY)
+      );
+    });
+  });
+
+  describe('should use secret', () => {
+    let jwtService: JwtService;
+
+    beforeAll(async () => {
+      jwtService = await setup({ ...config, secretOrKeyProvider: undefined });
+    });
+
+    it('signing should use secret key', async () => {
+      expect(await jwtService.sign('random')).toBe(config.secret);
+    });
+
+    it('signing (async) should use secret key', async () => {
+      expect(jwtService.signAsync('random')).resolves.toBe(config.secret);
+    });
+
+    it('verifying should use secret key', async () => {
+      expect(await jwtService.verify('random')).toBe(config.secret);
+    });
+
+    it('verifying (async) should use secret key', async () => {
+      expect(jwtService.verifyAsync('random')).resolves.toBe(config.secret);
+    });
+  });
+
+  describe('should use public/private key', () => {
+    let jwtService: JwtService;
+
+    beforeAll(async () => {
+      jwtService = await setup({
+        ...config,
+        secretOrKeyProvider: undefined,
+        secret: undefined
+      });
+    });
+
+    it('signing should use private key', async () => {
+      expect(await jwtService.sign('random')).toBe(config.privateKey);
+    });
+
+    it('signing (async) should use private key', async () => {
+      expect(jwtService.signAsync('random')).resolves.toBe(config.privateKey);
+    });
+
+    it('verifying should use public key', async () => {
+      expect(await jwtService.verify('random')).toBe(config.publicKey);
+    });
+
+    it('verifying (async) should use public key', async () => {
+      expect(jwtService.verifyAsync('random')).resolves.toBe(config.publicKey);
+    });
+  });
+
+  describe('override but warn deprecation for "secretOrKey"', () => {
+    let jwtService: JwtService;
+    let consoleCheck: jest.SpyInstance;
+
+    beforeAll(async () => {
+      jwtService = await setup({ ...config, secretOrPrivateKey: 'deprecated' });
+      consoleCheck = jest.spyOn(console, 'warn').mockImplementation(() => null);
+    });
+
+    it('signing should use deprecated secretOrPrivateKey', async () => {
+      expect(await jwtService.sign('random')).toBe('deprecated');
+      expect(consoleCheck).toHaveBeenCalledTimes(1);
+    });
+
+    it('signing (async) should use deprecated secretOrPrivateKey', async () => {
+      expect(jwtService.signAsync('random')).resolves.toBe('deprecated');
+      expect(consoleCheck).toHaveBeenCalledTimes(1);
+    });
+
+    it('verifying should use deprecated secretOrPrivateKey', async () => {
+      expect(await jwtService.verify('random')).toBe(config.publicKey);
+      expect(consoleCheck).toHaveBeenCalledTimes(1);
+    });
+
+    it('verifying (async) should use deprecated secretOrPrivateKey', async () => {
+      expect(jwtService.verifyAsync('random')).resolves.toBe(config.publicKey);
+      expect(consoleCheck).toHaveBeenCalledTimes(1);
+    });
+
+    afterEach(async () => {
+      consoleCheck.mockClear();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "reflect-metadata": "^0.1.13",
     "ts-jest": "^24.0.1",
     "prettier": "1.17.0",
-    "typescript": "3.4.2"
+    "typescript": "3.4.3"
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -1,25 +1,34 @@
 {
   "name": "@nestjs/jwt",
-  "version": "6.0.0",
+  "version": "6.0.4",
   "description": "Nest - modern, fast, powerful node.js web framework (@jwt)",
   "author": "Kamil Mysliwiec",
   "license": "MIT",
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json",
+    "test": "jest --config=jest.json",
+    "test:watch": "jest --watch --config=jest.json",
+    "test:coverage": "jest --config=jest.json --coverage --coverageDirectory=coverage",
     "precommit": "lint-staged",
     "prepublish:npm": "npm run build",
     "publish:npm": "npm publish --access public"
   },
   "peerDependencies": {
-    "@nestjs/common": "^6.0.0"
+    "@nestjs/common": "6.0.4"
   },
   "devDependencies": {
-    "@nestjs/common": "6.0.5",
+    "@nestjs/core": "^6.1.1",
+    "@nestjs/testing": "6.1.1",
+    "@types/jest": "^24.0.11",
+    "@nestjs/common": "6.1.1",
     "@types/node": "7.10.5",
     "husky": "0.14.3",
+    "jest": "^24.5.0",
     "lint-staged": "8.1.5",
-    "prettier": "1.16.4",
-    "typescript": "3.4.1"
+    "reflect-metadata": "^0.1.13",
+    "ts-jest": "^24.0.1",
+    "prettier": "1.17.0",
+    "typescript": "3.4.2"
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "reflect-metadata": "^0.1.13",
     "ts-jest": "^24.0.1",
     "prettier": "1.17.0",
-    "typescript": "3.4.3"
+    "typescript": "3.4.4"
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "reflect-metadata": "^0.1.13",
     "ts-jest": "^24.0.1",
     "prettier": "1.17.0",
-    "typescript": "3.4.4"
+    "typescript": "3.4.5"
   },
   "lint-staged": {
     "*.ts": [

--- a/tslint.json
+++ b/tslint.json
@@ -21,7 +21,7 @@
         "member-access": false,
         "ban-types": false,
         "max-classes-per-file": [
-            false
+            false, 1
         ],
         "member-ordering": [
             false


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behaviour?

There is no way to assign a secret dynamically.
Related to issue number: #26 

## What is the new behaviour?

With `secretOrKeyProvider` you can assign a secret or public/private key for each sign/verify request separately.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No //changed, see last commit
```

This PR introduces a ~~breaking~~ change how `secretOrPrivateKey` is assigned. Before, on the verification step the private Key was used when `publicKey` was not assigned due to `secretOrPrivateKey` function. Setting the secret or private/public key is now explicit. The following options set the secret now by priority:

1. `secretOrKeyProvider`
2. `secret`
3. `publicKey` and `privateKey`

*Edit*:

`secretOrKey` was re-added to smoothen out the upgrading process and takes precedence over the listed options above. With a deprecation warning and added tests this should be enough I hope. 

## Other information

~~I'm currently in the process of adding tests to this module. However, suggestions, critique or discussions are welcome. My time is quite limited but I'm happy to help and answer questions.~~

This is my first contribution to open source :) quite exciting tbh.