### PR TITLE
bugfix(): Remove toString on secrets for buffers

### DIFF
--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -10,16 +10,16 @@ export interface JwtModuleOptions {
   signOptions?: jwt.SignOptions;
   secret?: string | Buffer;
   publicKey?: string | Buffer;
-  privateKey?: jwt.Secret;
+  privateKey?: string | Buffer;
   /**
    * @deprecated
    */
-  secretOrPrivateKey?: jwt.Secret;
+  secretOrPrivateKey?: string | Buffer;
   secretOrKeyProvider?: (
     requestType: JwtSecretRequestType,
     tokenOrPayload: string | object | Buffer,
     options?: jwt.VerifyOptions | jwt.SignOptions
-  ) => jwt.Secret;
+  ) => string | Buffer;
   verifyOptions?: jwt.VerifyOptions;
 }
 

--- a/lib/jwt.service.ts
+++ b/lib/jwt.service.ts
@@ -63,7 +63,7 @@ export class JwtService {
       JwtSecretRequestType.VERIFY
     );
 
-    return jwt.verify(token, secret.toString(), verifyOptions) as T;
+    return jwt.verify(token, secret, verifyOptions) as T;
   }
 
   verifyAsync<T extends object = any>(
@@ -79,7 +79,7 @@ export class JwtService {
     );
 
     return new Promise((resolve, reject) =>
-      jwt.verify(token, secret.toString(), verifyOptions, (err, decoded) =>
+      jwt.verify(token, secret, verifyOptions, (err, decoded) =>
         err ? reject(err) : resolve(decoded as T)
       )
     ) as Promise<T>;
@@ -109,7 +109,7 @@ export class JwtService {
     options: jwt.VerifyOptions | jwt.SignOptions,
     key: 'publicKey' | 'privateKey',
     secretRequestType: JwtSecretRequestType
-  ): string | Buffer | jwt.Secret {
+  ): string | Buffer {
     let secret = this.options.secretOrKeyProvider
       ? this.options.secretOrKeyProvider(secretRequestType, token, options)
       : this.options.secret || this.options[key];


### PR DESCRIPTION
Change TS definitions to use string | buffer vs jwt.Secret.

https://github.com/nestjs/jwt/issues/94

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Allow Buffers for secrets for Base64 encoded keys.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
JWT verification fails if tokens had been signed with a Base64 encoded Buffer key

Issue Number: #94


## What is the new behavior?
The secret is no longer stringified when passed to the verify parameter


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

[See this comment](https://github.com/nestjs/jwt/issues/94#issuecomment-540677610)

This could be a feature that might be added in the future but might be worth calling out that this is not yet supported.