### PR TITLE
docs(README.md): show export of JwtModule in Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Import `JwtModule`:
 @Module({
   imports: [JwtModule.register({ secret: 'hard!to-guess_secret' })],
   providers: [...],
+  exports: [JwtModule]
 })
 export class AuthModule {}
 ```


### PR DESCRIPTION
Not exporting the JwtModule when used in the current Usage example creates an dependency resolution error for the AuthService.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:  Documentation change in README.md
```

## What is the current behavior?
If you use the Usage example as is you get an error.   This code used to work and it is unclear why thing sudden break after upgrading.  There were multiple unnecessary issues opened that may have been avoided.

Issue Number: 63 is an example of an issue that may have been avoided.

## What is the new behavior?
Using the code snippets directly will now work.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
## Other information