### PR TITLE
Allow secret to be passed as an option to sign and verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,19 +152,19 @@ It works the same as `useClass` with one critical difference - `JwtModule` will 
 
 The `JwtService` uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken) underneath.
 
-#### jwtService.sign(payload: string | Object | Buffer, options?: SignOptions): string
+#### jwtService.sign(payload: string | Object | Buffer, options?: JwtSignOptions): string
 
-The sign method is an implementation of jsonwebtoken `.sign()`.
+The sign method is an implementation of jsonwebtoken `.sign()`. Differing from jsonwebtoken it also allows an additional `secret` property on `options` to override the secret passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
 
-#### jwtService.signAsync(payload: string | Object | Buffer, options?: SignOptions): Promise\<string\>
+#### jwtService.signAsync(payload: string | Object | Buffer, options?: JwtSignOptions): Promise\<string\>
 
 The asynchronous `.sign()` method.
 
-#### jwtService.verify\<T extends object = any>(token: string, options?: VerifyOptions): T
+#### jwtService.verify\<T extends object = any>(token: string, options?: JwtVerifyOptions): T
 
-The verify method is an implementation of jsonwebtoken `.verify()`.
+The verify method is an implementation of jsonwebtoken `.verify()`. Differing from jsonwebtoken it also allows an additional `secret` property on `options` to override the secret passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
 
-#### jwtService.verifyAsync\<T extends object = any>(token: string, options?: VerifyOptions): Promise\<T\>
+#### jwtService.verifyAsync\<T extends object = any>(token: string, options?: JwtVerifyOptions): Promise\<T\>
 
 The asynchronous `.verify()` method.
 

--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -33,3 +33,11 @@ export interface JwtModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
   useFactory?: (...args: any[]) => Promise<JwtModuleOptions> | JwtModuleOptions;
   inject?: any[];
 }
+
+export interface JwtSignOptions extends jwt.SignOptions {
+  secret?: string | Buffer;
+}
+
+export interface JwtVerifyOptions extends jwt.VerifyOptions {
+  secret?: string | Buffer;
+}

--- a/lib/jwt.service.spec.ts
+++ b/lib/jwt.service.spec.ts
@@ -191,4 +191,35 @@ describe('JWT Service', () => {
         .mockImplementation((token, secret, options) => secret);
     });
   });
+
+  describe('should use secret key from options', () => {
+    let jwtService: JwtService;
+
+    beforeAll(async () => {
+      jwtService = await setup({
+        ...config,
+        secretOrKeyProvider: undefined
+      });
+    });
+
+    let secret = 'custom';
+
+    it('signing should use secret key from options', async () => {
+      expect(await jwtService.sign('random', { secret })).toBe(secret);
+    });
+
+    it('signing (async) should use secret key from options', async () => {
+      expect(jwtService.signAsync('random', { secret })).resolves.toBe(secret);
+    });
+
+    it('verifying should use secret key from options', async () => {
+      expect(await jwtService.verify('random', { secret })).toBe(secret);
+    });
+
+    it('verifying (async) should use secret key from options', async () => {
+      expect(jwtService.verifyAsync('random', { secret })).resolves.toBe(
+        secret
+      );
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is currently no way to override the secret passed in from the module. This makes it difficult if you want to use a different secret for two different sign calls for example and `access token` and a `refresh token`

Issue Number: #302 

## What is the new behavior?
The new behaviour allows you to pass a secret in to the sign, signAsync, verify and verifyAsync methods to override the secret from the one passed into the module. It does not override the `secretOrKeyProvider` though.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
It's possible you may want the secret to override the `secretOrKeyProvider` but I wasn't sure. Happy to tweak this PR if you'd prefer it that way.