### PR TITLE
chore(deps): move @types/jsonwebtoken to development dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2090,6 +2090,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
       "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -2112,7 +2113,8 @@
     "@types/node": {
       "version": "7.10.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.9.tgz",
-      "integrity": "sha512-usSpgoUsRtO5xNV5YEPU8PPnHisFx8u0rokj1BPVn/hDF7zwUDzVLiuKZM38B7z8V2111Fj6kd4rGtQFUZpNOw=="
+      "integrity": "sha512-usSpgoUsRtO5xNV5YEPU8PPnHisFx8u0rokj1BPVn/hDF7zwUDzVLiuKZM38B7z8V2111Fj6kd4rGtQFUZpNOw==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@commitlint/cli": "9.1.2",
     "@commitlint/config-angular": "9.1.2",
+    "@types/jsonwebtoken": "^8.5.0",
     "jest": "26.4.1",
     "ts-jest": "26.2.0",
     "reflect-metadata": "0.1.13",
@@ -43,7 +44,6 @@
     "typescript": "4.0.2"
   },
   "dependencies": {
-    "@types/jsonwebtoken": "8.5.0",
     "jsonwebtoken": "8.5.1"
   },
   "lint-staged": {


### PR DESCRIPTION
This PRQ moves the `@types/jsonwebtoken` dependency to `devDependencies`. Version is unchanged.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ]  Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


