### PR TITLE
feat: Allow private/public key to be override when signing/verifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The `JwtService` uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
 
 #### jwtService.sign(payload: string | Object | Buffer, options?: JwtSignOptions): string
 
-The sign method is an implementation of jsonwebtoken `.sign()`. Differing from jsonwebtoken it also allows an additional `secret, privateKey, publicKey` property on `options` to override the secret passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
+The sign method is an implementation of jsonwebtoken `.sign()`. Differing from jsonwebtoken it also allows an additional `secret`, `privateKey`, and `publicKey` properties on `options` to override options passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
 
 #### jwtService.signAsync(payload: string | Object | Buffer, options?: JwtSignOptions): Promise\<string\>
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The `JwtService` uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
 
 #### jwtService.sign(payload: string | Object | Buffer, options?: JwtSignOptions): string
 
-The sign method is an implementation of jsonwebtoken `.sign()`. Differing from jsonwebtoken it also allows an additional `secret` property on `options` to override the secret passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
+The sign method is an implementation of jsonwebtoken `.sign()`. Differing from jsonwebtoken it also allows an additional `secret, privateKey, publicKey` property on `options` to override the secret passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
 
 #### jwtService.signAsync(payload: string | Object | Buffer, options?: JwtSignOptions): Promise\<string\>
 
@@ -162,7 +162,7 @@ The asynchronous `.sign()` method.
 
 #### jwtService.verify\<T extends object = any>(token: string, options?: JwtVerifyOptions): T
 
-The verify method is an implementation of jsonwebtoken `.verify()`. Differing from jsonwebtoken it also allows an additional `secret` property on `options` to override the secret passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
+The verify method is an implementation of jsonwebtoken `.verify()`. Differing from jsonwebtoken it also allows an additional `secret, privateKey, publicKey` property on `options` to override the secret passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
 
 #### jwtService.verifyAsync\<T extends object = any>(token: string, options?: JwtVerifyOptions): Promise\<T\>
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The asynchronous `.sign()` method.
 
 #### jwtService.verify\<T extends object = any>(token: string, options?: JwtVerifyOptions): T
 
-The verify method is an implementation of jsonwebtoken `.verify()`. Differing from jsonwebtoken it also allows an additional `secret, privateKey, publicKey` property on `options` to override the secret passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
+The verify method is an implementation of jsonwebtoken `.verify()`. Differing from jsonwebtoken it also allows an additional `secret`, `privateKey`, and `publicKey` properties on `options` to override options passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
 
 #### jwtService.verifyAsync\<T extends object = any>(token: string, options?: JwtVerifyOptions): Promise\<T\>
 

--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -36,8 +36,10 @@ export interface JwtModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
 
 export interface JwtSignOptions extends jwt.SignOptions {
   secret?: string | Buffer;
+  privateKey?: string | Buffer;
 }
 
 export interface JwtVerifyOptions extends jwt.VerifyOptions {
   secret?: string | Buffer;
+  publicKey?: string | Buffer;
 }

--- a/lib/jwt.service.spec.ts
+++ b/lib/jwt.service.spec.ts
@@ -222,4 +222,39 @@ describe('JWT Service', () => {
       );
     });
   });
+
+  describe('should use private/public key from options', () => {
+    let jwtService: JwtService;
+
+    beforeAll(async () => {
+      jwtService = await setup({
+        ...config,
+        secretOrKeyProvider: undefined,
+        secret: undefined
+      });
+    });
+
+    let privateKey = 'customPrivateKey';
+    let publicKey = 'customPublicKey';
+
+    it('signing should use private key from options', async () => {
+      expect(await jwtService.sign('random', { privateKey })).toBe(privateKey);
+    });
+
+    it('signing (async) should use private key from options', async () => {
+      expect(jwtService.signAsync('random', { privateKey })).resolves.toBe(
+        privateKey
+      );
+    });
+
+    it('verifying should use public key from options', async () => {
+      expect(await jwtService.verify('random', { publicKey })).toBe(publicKey);
+    });
+
+    it('verifying (async) should use public key from options', async () => {
+      expect(jwtService.verifyAsync('random', { publicKey })).resolves.toBe(
+        publicKey
+      );
+    });
+  });
 });

--- a/lib/jwt.service.ts
+++ b/lib/jwt.service.ts
@@ -96,6 +96,11 @@ export class JwtService {
     key: 'verifyOptions' | 'signOptions'
   ): jwt.VerifyOptions | jwt.SignOptions {
     delete options.secret;
+    if (key === 'signOptions') {
+      delete (options as JwtSignOptions).privateKey;
+    } else {
+      delete (options as JwtVerifyOptions).publicKey;
+    }
     return options
       ? {
           ...(this.options[key] || {}),
@@ -112,7 +117,13 @@ export class JwtService {
   ): string | Buffer | jwt.Secret {
     let secret = this.options.secretOrKeyProvider
       ? this.options.secretOrKeyProvider(secretRequestType, token, options)
-      : options?.secret || this.options.secret || this.options[key];
+      : options?.secret ||
+        this.options.secret ||
+        (key === 'privateKey'
+          ? (options as JwtSignOptions)?.privateKey || this.options.privateKey
+          : (options as JwtVerifyOptions)?.publicKey ||
+            this.options.publicKey) ||
+        this.options[key];
 
     if (this.options.secretOrPrivateKey) {
       this.logger.warn(


### PR DESCRIPTION
This allows you to pass the `privateKey` property in the options of sign, signAsync and `publicKey` in the verify, verifyAsync. It does not override a secretOrKeyProvider though only the `privateKey` and `publicKey` passed into the JwtModule.

Resolves [#302](https://github.com/nestjs/jwt/issues/302)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently there's no way to override `privateKey` and `publicKey` passed in from the module. This makes it difficult in case of we want to use multiple keys to sign and verify JWT token. Example: in a multi-tenant app, each tenant will have its own private/public key to sign its user's token.

Issue Number: [320](https://github.com/nestjs/jwt/issues/302)


## What is the new behavior?
It's now possible to override `privateKey` and `publicKey` from the module when signing/verifying token.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```