### PR TITLE
docs: update configService code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Obviously, our factory behaves like every other one (might be `async` and is abl
 JwtModule.registerAsync({
   imports: [ConfigModule],
   useFactory: async (configService: ConfigService) => ({
-    secret: configService.getString('SECRET'),
+    secret: configService.get<string>('SECRET'),
   }),
   inject: [ConfigService],
 }),


### PR DESCRIPTION
## PR Type
Small docs update.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the Async Options, an example with `ConfigModule` is being used where `configServices` uses `getString` that now should be `get`.
```ts
JwtModule.registerAsync({
  imports: [ConfigModule],
  useFactory: async (configService: ConfigService) => ({
    secret: configService.getString('SECRET'),
  }),
  inject: [ConfigService],
}),
```