### PR TITLE
feat(): support for asynchronous version of `secretOrKeyProvider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ export class AuthService {
 
 ## Secret / Encryption Key options
 
-If you want to control secret and key management dynamically you can use the `secretOrKeyProvider` function for that purpose.
+If you want to control secret and key management dynamically you can use the `secretOrKeyProvider` function for that purpose. You also can use asynchronous version of `secretOrKeyProvider`.
+NOTE: For asynchronous version of `secretOrKeyProvider`, synchronous versions of `.sing()` and `.verify()` will throw an exception.
 
 ```typescript
 JwtModule.register({
@@ -155,6 +156,7 @@ The `JwtService` uses [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
 #### jwtService.sign(payload: string | Object | Buffer, options?: JwtSignOptions): string
 
 The sign method is an implementation of jsonwebtoken `.sign()`. Differing from jsonwebtoken it also allows an additional `secret`, `privateKey`, and `publicKey` properties on `options` to override options passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
+NOTE: Will throw an exception for asynchronous version of `secretOrKeyProvider`;
 
 #### jwtService.signAsync(payload: string | Object | Buffer, options?: JwtSignOptions): Promise\<string\>
 
@@ -163,6 +165,7 @@ The asynchronous `.sign()` method.
 #### jwtService.verify\<T extends object = any>(token: string, options?: JwtVerifyOptions): T
 
 The verify method is an implementation of jsonwebtoken `.verify()`. Differing from jsonwebtoken it also allows an additional `secret`, `privateKey`, and `publicKey` properties on `options` to override options passed in from the module. It only overrides the `secret`, `publicKey` or `privateKey` though not a `secretOrKeyProvider`.
+NOTE: Will throw an exception for asynchronous version of `secretOrKeyProvider`;
 
 #### jwtService.verifyAsync\<T extends object = any>(token: string, options?: JwtVerifyOptions): Promise\<T\>
 
@@ -175,7 +178,7 @@ The decode method is an implementation of jsonwebtoken `.decode()`.
 The `JwtModule` takes an `options` object:
 
 - `secret` is either a string, buffer, or object containing the secret for HMAC algorithms
-- `secretOrKeyProvider` function with the following signature `(requestType, tokenOrPayload, options?) => jwt.Secret` (allows generating either secrets or keys dynamically)
+- `secretOrKeyProvider` function with the following signature `(requestType, tokenOrPayload, options?) => jwt.Secret | Promise<jwt.Secret>` (allows generating either secrets or keys dynamically)
 - `signOptions` [read more](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback)
 - `privateKey` PEM encoded private key for RSA and ECDSA with passphrase an object `{ key, passphrase }` [read more](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback)
 - `publicKey` PEM encoded public key for RSA and ECDSA

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './interfaces';
+export * from './jwt.errors';
 export * from './jwt.module';
 export * from './jwt.service';

--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -19,7 +19,7 @@ export interface JwtModuleOptions {
     requestType: JwtSecretRequestType,
     tokenOrPayload: string | object | Buffer,
     options?: jwt.VerifyOptions | jwt.SignOptions
-  ) => jwt.Secret;
+  ) => jwt.Secret | Promise<jwt.Secret>;
   verifyOptions?: jwt.VerifyOptions;
 }
 
@@ -43,3 +43,5 @@ export interface JwtVerifyOptions extends jwt.VerifyOptions {
   secret?: string | Buffer;
   publicKey?: string | Buffer;
 }
+
+export type GetSecretKeyResult = string | Buffer | jwt.Secret;

--- a/lib/jwt.errors.ts
+++ b/lib/jwt.errors.ts
@@ -1,0 +1,1 @@
+export class WrongSecretProviderError extends Error {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #235 


## What is the new behavior?
Allow ability to provide an asynchronous version of `secretOrKeyProvider`. However, when using asynchronous verison of `secretOrKeyProvider`, synchronous versions of `.sing` and `.verify` will log a warning message and throw an exception before calling `.sing` or `.verify`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm not sure if this PR contains breaking changes, because synchronous versions of `.sing` and` .verify` can throw exceptions as well.