### PR TITLE
Types: add generic to decode()

### DIFF
--- a/lib/jwt.service.ts
+++ b/lib/jwt.service.ts
@@ -86,10 +86,10 @@ export class JwtService {
     ) as Promise<T>;
   }
 
-  decode(
+  decode<T = null | { [key: string]: any } | string>(
     token: string,
     options?: jwt.DecodeOptions
-  ): null | { [key: string]: any } | string {
+  ): T {
     return jwt.decode(token, options);
   }
 


### PR DESCRIPTION
Usage example:
```
type ABType = {
 a: string;
 b: string;
};

const { a, b } = this.jwtService.decode<ABType>(some_jwt);
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
