### PR TITLE
fix: allow object for overriding private key when signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - run:
           name: Update NPM version
-          command: npm install -g npm@latest
+          command: npm install -g npm@^8
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:

--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -36,7 +36,7 @@ export interface JwtModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
 
 export interface JwtSignOptions extends jwt.SignOptions {
   secret?: string | Buffer;
-  privateKey?: string | Buffer;
+  privateKey?: jwt.Secret;
 }
 
 export interface JwtVerifyOptions extends jwt.VerifyOptions {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

It must be able to pass an object `{ key, passphrase }` as privateKey for RSA and ECDSA algorithm.
It's possible on module option but not on overriding private key when signing.

## What is the new behavior?
Fix privateKey type to allow to pass object for overriding private key when signing

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
