### PR TITLE
fix: Match privateKey type in both JwtModuleOptions and JwtSignOptions

### DIFF
--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -36,7 +36,7 @@ export interface JwtModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
 
 export interface JwtSignOptions extends jwt.SignOptions {
   secret?: string | Buffer;
-  privateKey?: string | Buffer;
+  privateKey?: jwt.Secret;
 }
 
 export interface JwtVerifyOptions extends jwt.VerifyOptions {

--- a/lib/jwt.service.spec.ts
+++ b/lib/jwt.service.spec.ts
@@ -32,7 +32,11 @@ describe('JWT Service', () => {
     signSpy = jest
       .spyOn(jwt, 'sign')
       .mockImplementation((token, secret, options, callback) => {
-        const result = 'signed_' + token + '_by_' + secret;
+        const ssecret =
+          secret.hasOwnProperty('key')
+            ? secret['key']
+            : secret;
+        const result = 'signed_' + token + '_by_' + ssecret;
         return callback ? callback(null, result) : result;
       });
 
@@ -131,6 +135,22 @@ describe('JWT Service', () => {
       expect(await jwtService.sign(testPayload)).toBe(
         `signed_${testPayload}_by_private_key`
       );
+    });
+
+    it('signing should use overriden string privateKey', async () => {
+      expect(
+        await jwtService.sign(testPayload, {
+          privateKey: 'another_private_key'
+        })
+      ).toBe(`signed_${testPayload}_by_another_private_key`);
+    });
+
+    it('signing should use overriden passphrase-encoded privateKey', async () => {
+      expect(
+        await jwtService.sign(testPayload, {
+          privateKey: { key: 'encoded_private_key', passphrase: 'passphrase' }
+        })
+      ).toBe(`signed_${testPayload}_by_encoded_private_key`);
     });
 
     it('signing (async) should use config.privateKey', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Dynamically sending a privateKey to jwtService.sign() (as opposed to using the JwtModule config) does not support passphrase encoded types (inconsistency in the Typescript interface). 

Issue Number: N/A

## What is the new behavior?
JwtSignOptions now supports passphrase encoded private key (using jwtService.sign()).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
jwt.Secret type includes  `string | Buffer` as well as `{ key: string | Buffer; passphrase: string }`.
This change is required in order to enable using a `{key,passphrase}`-structured `privateKey` in jwtService.sign() calls like it does in JwtModule.register(). 
The use case is when you want to dynamically provide such key to the `sign` method (e.g. when each user/token has a different key pair).