### PR TITLE
fix(sign): params types and behavior

### DIFF
--- a/lib/jwt.service.spec.ts
+++ b/lib/jwt.service.spec.ts
@@ -303,4 +303,79 @@ describe('JWT Service', () => {
       ).resolves.toBe(`verified_${testPayload}_by_customPublicKey`);
     });
   });
+
+  describe('should not use invalid sign options', () => {
+    let jwtService: JwtService;
+    let testPayloadStr: string = getRandomString();
+
+    beforeAll(async () => {
+      jwtService = await setup({ secretOrKeyProvider: undefined });
+    });
+
+    it('should not "sign" expect errors with a "payload" string and "secret"', () => {
+      // @ts-expect-no-error
+      expect(() => jwtService.sign(testPayloadStr, { secret: 'secret' }));
+    });
+
+    it('should not "signAsync" expect errors with a "payload" string and "privateKey"', () => {
+      // @ts-expect-no-error
+      expect(() =>
+        jwtService.signAsync(testPayloadStr, { privateKey: 'privateKey' })
+      );
+    });
+  });
+
+  describe('should use invalid sign options', () => {
+    const signOptions: jwt.SignOptions = {
+      expiresIn: '1d'
+    };
+
+    let jwtService: JwtService;
+    let testPayloadStr: string = getRandomString();
+    let testPayloadObj: object = {};
+
+    beforeAll(async () => {
+      jwtService = await setup({ signOptions, secretOrKeyProvider: undefined });
+    });
+
+    it('should "sign" expect errors with a "payload" string with "expiresIn"', () => {
+      expect(() =>
+        // @ts-expect-error
+        jwtService.sign(testPayloadStr, { expiresIn: 60 })
+      ).toThrowError(
+        'Not allowed payload as string with these sign options: expiresIn'
+      );
+    });
+
+    it('should "signAsync" expect errors with a "payload" string with "notBefore"', () => {
+      expect(() =>
+        // @ts-expect-error
+        jwtService.signAsync(testPayloadStr, { notBefore: 60 })
+      ).toThrowError(
+        'Not allowed payload as string with these sign options: expiresIn, notBefore'
+      );
+    });
+
+    it('should not "sign" expect errors with a "payload" object with "notBefore" ', () => {
+      // @ts-expect-no-error
+      expect(() => jwtService.sign(testPayloadObj, { notBefore: 60 }));
+    });
+
+    it('should not "signAsync" expect errors with a "payload" object with "notBefore" ', () => {
+      // @ts-expect-no-error
+      expect(() => jwtService.signAsync(testPayloadObj, { notBefore: 60 }));
+    });
+
+    it('should "sign" expect errors using "payload" string with already defined invalid sign options', () => {
+      expect(() => jwtService.sign(testPayloadStr)).toThrowError(
+        'Not allowed payload as string with these sign options: expiresIn'
+      );
+    });
+
+    it('should "signAsync" expect errors using "payload" string with already defined invalid sign options', () => {
+      expect(() => jwtService.signAsync(testPayloadStr)).toThrowError(
+        'Not allowed payload as string with these sign options: expiresIn'
+      );
+    });
+  });
 });

--- a/lib/jwt.service.ts
+++ b/lib/jwt.service.ts
@@ -18,6 +18,11 @@ export class JwtService {
     private readonly options: JwtModuleOptions = {}
   ) {}
 
+  sign(
+    payload: string,
+    options?: Omit<JwtSignOptions, keyof jwt.SignOptions>
+  ): string;
+  sign(payload: Buffer | object, options?: JwtSignOptions): string;
   sign(payload: string | Buffer | object, options?: JwtSignOptions): string {
     const signOptions = this.mergeJwtOptions(
       { ...options },
@@ -30,9 +35,29 @@ export class JwtService {
       JwtSecretRequestType.SIGN
     );
 
+    const allowedSignOptKeys = ['secret', 'privateKey'];
+    const signOptKeys = Object.keys(signOptions);
+    if (
+      typeof payload === 'string' &&
+      signOptKeys.some((k) => !allowedSignOptKeys.includes(k))
+    ) {
+      throw new Error(
+        'Not allowed payload as string with these sign options: ' +
+          signOptKeys.join(', ')
+      );
+    }
+
     return jwt.sign(payload, secret, signOptions);
   }
 
+  signAsync(
+    payload: string,
+    options?: Omit<JwtSignOptions, keyof jwt.SignOptions>
+  ): Promise<string>;
+  signAsync(
+    payload: Buffer | object,
+    options?: JwtSignOptions
+  ): Promise<string>;
   signAsync(
     payload: string | Buffer | object,
     options?: JwtSignOptions
@@ -47,6 +72,18 @@ export class JwtService {
       'privateKey',
       JwtSecretRequestType.SIGN
     );
+
+    const allowedSignOptKeys = ['secret', 'privateKey'];
+    const signOptKeys = Object.keys(signOptions);
+    if (
+      typeof payload === 'string' &&
+      signOptKeys.some((k) => !allowedSignOptKeys.includes(k))
+    ) {
+      throw new Error(
+        'Not allowed payload as string with these sign options: ' +
+          signOptKeys.join(', ')
+      );
+    }
 
     return new Promise((resolve, reject) =>
       jwt.sign(payload, secret, signOptions, (err, encoded) =>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The sing payload and signOptions parameters have accepts wrong parameters values.
In jsonwebtoken it is not allowed to use payload as string and set some specific options (invalid options) such as "expiresIn" property. Hence the source code breaks.

Example of the issue in code:
https://gist.github.com/Hender-hs/542ccb2c7c3c1b4216fdb7ae9c8cf3c2

Issue Number: N/A


## What is the new behavior?
Now the typescript will check for developer's input in the sign method, using overload methods for correct values, in specific scenario.
Also was added a procedure to check at the runtime and throw an error if the parameters was passed incorrectly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Example of the issue in code:
https://gist.github.com/Hender-hs/542ccb2c7c3c1b4216fdb7ae9c8cf3c2