### PR TITLE
Feature(export): exports jsonwebtoken errors to allow using them with…

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './interfaces';
 export * from './jwt.module';
 export * from './jwt.service';
+export { TokenExpiredError, NotBeforeError, JsonWebTokenError } from 'jsonwebtoken';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1437 


## What is the new behavior?
To allow usage of "instanceof" the jsonwebtoken package version must match the jsonwebtoken version in @nestjs/jwt. 

This exposes TokenExpiredError, NotBeforeError, JsonWebTokenError from @nest/jwt to be used with instanceof

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
