### PR TITLE
perf: Allow `secret` and `publicKey` options to be `crypto.KeyObject` (2x to 50x faster calls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ The `JwtModule` takes an `options` object:
 - `verifyOptions` [read more](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)
 - `secretOrPrivateKey` (DEPRECATED!) [read more](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback)
 
+For performance purposes, it is advised to pass instances of `KeyObject` to `secret`, `privateKey` and `publicKey` properties of this `options` object. These `KeyObject` can be generated with `createSecretKey()`, `createPrivateKey()` and `createPublicKey()` from Node.js `crypto` module. For example:
+
+```typescript
+import { createSecretKey } from 'crypto';
+
+new JwtService({
+  secret: createSecretKey(Buffer.from('the secret key'))
+});
+```
+
 ## Support
 
 Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).

--- a/lib/interfaces/jwt-module-options.interface.ts
+++ b/lib/interfaces/jwt-module-options.interface.ts
@@ -12,8 +12,8 @@ export enum JwtSecretRequestType {
 export interface JwtModuleOptions {
   global?: boolean;
   signOptions?: jwt.SignOptions;
-  secret?: string | Buffer;
-  publicKey?: string | Buffer;
+  secret?: jwt.Secret;
+  publicKey?: jwt.Secret;
   privateKey?: jwt.Secret;
   /**
    * @deprecated


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Feature
- [x] Performance

## Current and new behaviors

When JwtService is initialized with `publicKey` as a string or Buffer, `verify()` and `verifyAsync()` pass it to "jsonwebtoken.verify()", which creates an instance of `crypto.KeyObject` from it via `crypto.createPublicKey()`. This is not free. Initializing `publicKey` with a `KeyObject` avoids this transformation in "jsonwebtoken". On my laptop, it makes `verify` twice faster.

The same goes for `secret`, used in `sign()`, `verify()` and their asynchronous variants. Initializing with a `KeyObject` (built via `crypto.createSecretKey`) makes these functions ~50 times faster.

See also auth0/node-jsonwebtoken#966, which reports similar gains.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

I tentatively updated the README. Suggestions are most welcome! :)  (Note that this README links to `jsonwebtoken` own README, which has yet to be updated (see [aforementioned issue](https://github.com/auth0/node-jsonwebtoken/issues/966)).).